### PR TITLE
Implement sample loading and playback scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+JUCE/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.15)
+project(InstruAI VERSION 0.1.0)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Expect JUCE to be available in a subdirectory named JUCE or via FETCHCONTENT
+# Users should add JUCE as a submodule or adjust the path accordingly.
+add_subdirectory(JUCE)
+
+juce_add_plugin(InstruAI
+    COMPANY_NAME "InstruAI"
+    PLUGIN_MANUFACTURER_CODE InAI
+    PLUGIN_CODE InsA
+    FORMATS VST3
+    PRODUCT_NAME "InstruAI"
+    IS_SYNTH TRUE
+    NEEDS_MIDI_INPUT TRUE
+    NEEDS_MIDI_OUTPUT FALSE
+    IS_MIDI_EFFECT FALSE
+    EDITOR_WANTS_KEYBOARD_FOCUS TRUE
+)
+
+target_sources(InstruAI PRIVATE
+    Source/PluginProcessor.cpp
+    Source/PluginEditor.cpp
+)
+
+target_link_libraries(InstruAI PRIVATE
+    juce::juce_audio_utils
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# InstruAI
+
+This repository contains the beginnings of a JUCE-based VST3 instrument.
+The plugin will allow users to type a text prompt or load an audio sample,
+then generate an array of samples distributed across MIDI notes and velocity
+layers.
+
+## Building
+
+1. Clone the JUCE framework into a folder named `JUCE` next to the project:
+   ```sh
+   git submodule add https://github.com/juce-framework/JUCE JUCE
+   ```
+2. Generate the build system with CMake:
+   ```sh
+   cmake -B build -S .
+   cmake --build build
+   ```
+
+The current codebase is an initial skeleton featuring a simple user interface
+with a text editor, buttons, and a piano keyboard component.

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1,0 +1,72 @@
+#include "PluginEditor.h"
+#include "PluginProcessor.h"
+
+InstruAIaudioProcessorEditor::InstruAIaudioProcessorEditor(InstruAIaudioProcessor& p)
+    : AudioProcessorEditor(&p), processor(p),
+      keyboardComponent(keyboardState, juce::MidiKeyboardComponent::horizontalKeyboard)
+{
+    addAndMakeVisible(keyboardComponent);
+
+    addAndMakeVisible(promptEditor);
+    promptEditor.setMultiLine(true);
+    promptEditor.setText("Enter text prompt...");
+
+    addAndMakeVisible(loadSampleButton);
+    loadSampleButton.addListener(this);
+
+    addAndMakeVisible(generateButton);
+    generateButton.addListener(this);
+
+    sampleCountLabel.setText("N", juce::dontSendNotification);
+    addAndMakeVisible(sampleCountLabel);
+    sampleCountSlider.setRange(1, 8, 1);
+    sampleCountSlider.setValue(1);
+    addAndMakeVisible(sampleCountSlider);
+
+    velocityLayerLabel.setText("M", juce::dontSendNotification);
+    addAndMakeVisible(velocityLayerLabel);
+    velocityLayerSlider.setRange(1, 4, 1);
+    velocityLayerSlider.setValue(1);
+    addAndMakeVisible(velocityLayerSlider);
+
+    setSize(600, 200);
+}
+
+InstruAIaudioProcessorEditor::~InstruAIaudioProcessorEditor() = default;
+
+void InstruAIaudioProcessorEditor::paint(juce::Graphics& g)
+{
+    g.fillAll(juce::Colours::black);
+}
+
+void InstruAIaudioProcessorEditor::resized()
+{
+    auto area = getLocalBounds().reduced(10);
+    auto topArea = area.removeFromTop(40);
+    promptEditor.setBounds(topArea.removeFromLeft(area.getWidth() - 320));
+    loadSampleButton.setBounds(topArea.removeFromLeft(100));
+    generateButton.setBounds(topArea.removeFromLeft(100));
+    sampleCountLabel.setBounds(topArea.removeFromLeft(20));
+    sampleCountSlider.setBounds(topArea.removeFromLeft(50));
+    velocityLayerLabel.setBounds(topArea.removeFromLeft(20));
+    velocityLayerSlider.setBounds(topArea.removeFromLeft(50));
+    keyboardComponent.setBounds(area);
+}
+
+void InstruAIaudioProcessorEditor::buttonClicked(juce::Button* button)
+{
+    if (button == &loadSampleButton)
+    {
+        juce::FileChooser chooser("Select an audio file");
+        if (chooser.browseForFileToOpen())
+        {
+            processor.loadSample(chooser.getResult());
+        }
+    }
+    else if (button == &generateButton)
+    {
+        juce::String prompt = promptEditor.getText();
+        juce::ignoreUnused(prompt);
+        // TODO: trigger generation from text prompt
+    }
+}

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "PluginProcessor.h"
+
+class InstruAIaudioProcessorEditor : public juce::AudioProcessorEditor,
+                                     private juce::Button::Listener
+{
+public:
+    InstruAIaudioProcessorEditor(InstruAIaudioProcessor&);
+    ~InstruAIaudioProcessorEditor() override;
+
+    void paint(juce::Graphics&) override;
+    void resized() override;
+
+private:
+    void buttonClicked(juce::Button* button) override;
+
+    InstruAIaudioProcessor& processor;
+
+    juce::MidiKeyboardState keyboardState;
+    juce::MidiKeyboardComponent keyboardComponent;
+
+      juce::TextEditor promptEditor;
+      juce::TextButton loadSampleButton { "Load Sample" };
+      juce::TextButton generateButton { "Generate" };
+
+      juce::Slider sampleCountSlider;
+      juce::Label sampleCountLabel;
+      juce::Slider velocityLayerSlider;
+      juce::Label velocityLayerLabel;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(InstruAIaudioProcessorEditor)
+};

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1,0 +1,66 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+InstruAIaudioProcessor::InstruAIaudioProcessor()
+    : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true))
+{
+    formatManager.registerBasicFormats();
+
+    for (int i = 0; i < 8; ++i)
+        sampler.addVoice(new juce::SamplerVoice());
+}
+
+InstruAIaudioProcessor::~InstruAIaudioProcessor() = default;
+
+void InstruAIaudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
+{
+    juce::ignoreUnused(sampleRate, samplesPerBlock);
+}
+
+void InstruAIaudioProcessor::releaseResources()
+{
+}
+
+bool InstruAIaudioProcessor::isBusesLayoutSupported(const BusesLayout& layouts) const
+{
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono() &&
+        layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+        return false;
+    return true;
+}
+
+void InstruAIaudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
+{
+    buffer.clear();
+    sampler.renderNextBlock(buffer, midiMessages, 0, buffer.getNumSamples());
+}
+
+juce::AudioProcessorEditor* InstruAIaudioProcessor::createEditor()
+{
+    return new InstruAIaudioProcessorEditor(*this);
+}
+
+void InstruAIaudioProcessor::getStateInformation(juce::MemoryBlock& destData)
+{
+    juce::ignoreUnused(destData);
+}
+
+void InstruAIaudioProcessor::setStateInformation(const void* data, int sizeInBytes)
+{
+    juce::ignoreUnused(data, sizeInBytes);
+}
+
+void InstruAIaudioProcessor::loadSample(const juce::File& file)
+{
+    std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(file));
+    if (reader != nullptr)
+    {
+        juce::BigInteger notes;
+        notes.setRange(0, 128, true);
+
+        auto sound = std::make_unique<juce::SamplerSound>(file.getFileName(), *reader, notes,
+                                                          60, 0.0, 0.0,
+                                                          reader->lengthInSamples / reader->sampleRate);
+        sampler.addSound(sound.release());
+    }
+}

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+class InstruAIaudioProcessor : public juce::AudioProcessor
+{
+public:
+    InstruAIaudioProcessor();
+    ~InstruAIaudioProcessor() override;
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+    bool isBusesLayoutSupported(const BusesLayout& layouts) const override;
+
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override { return true; }
+
+    const juce::String getName() const override { return JucePlugin_Name; }
+
+    bool acceptsMidi() const override { return true; }
+    bool producesMidi() const override { return false; }
+    bool isMidiEffect() const override { return false; }
+    double getTailLengthSeconds() const override { return 0.0; }
+
+    int getNumPrograms() override { return 1; }
+    int getCurrentProgram() override { return 0; }
+    void setCurrentProgram(int index) override {}
+    const juce::String getProgramName(int index) override { return {}; }
+    void changeProgramName(int index, const juce::String& newName) override {}
+
+    void getStateInformation(juce::MemoryBlock& destData) override;
+    void setStateInformation(const void* data, int sizeInBytes) override;
+
+    /** Load an audio sample from disk and map it across the keyboard. */
+    void loadSample(const juce::File& file);
+
+private:
+    juce::Synthesiser sampler;
+    juce::AudioFormatManager formatManager;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(InstruAIaudioProcessor)
+};


### PR DESCRIPTION
## Summary
- Introduced a `Synthesiser`-based engine with audio format support and an API to load samples across the keyboard.
- Wired the editor to load user-selected audio files and added sliders for sample and velocity counts.

## Testing
- `cmake -B build -S .` *(fails: add_subdirectory given source "JUCE" which is not an existing directory)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68b75e81ba688329af5e73f19dca6c93